### PR TITLE
update tests and gradle libs

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-1284865770">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36.1" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-1001704751">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36.1" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="2066065764">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36.1" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,7 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-21" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -14,19 +16,21 @@ ksp {
 
 android {
     namespace 'com.example.networkproject'
-    compileSdk 36
+    compileSdk = 36
     
-    // Only include shared code in unit tests to avoid duplicate content roots warning
     sourceSets {
-        test {
-            java.srcDirs += ['src/testShared/java']
+        named("test") {
+            kotlin.srcDir("src/testShared/java")
+        }
+        named("androidTest") {
+            kotlin.srcDir("src/testShared/java")
         }
     }
 
     defaultConfig {
         applicationId "com.example.networkproject"
-        minSdk 21
-        targetSdk 35
+        minSdk 23
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 

--- a/app/src/androidTest/java/com/example/networkproject/data/database/EmployeeDaoTest.kt
+++ b/app/src/androidTest/java/com/example/networkproject/data/database/EmployeeDaoTest.kt
@@ -12,10 +12,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import com.example.networkproject.test.TestData
 import java.io.IOException
 import javax.inject.Inject
-import javax.inject.Named
 
 @HiltAndroidTest
 class EmployeeDaoTest {
@@ -45,7 +43,7 @@ class EmployeeDaoTest {
     @Test
     @Throws(Exception::class)
     fun writeUserAndReadInList() = runBlocking {
-        val employee: Employee = TestData.employeeTestList.first()
+        val employee: Employee = Employee(1, "Leanne Graham", "Bret", "Sincere@april.biz")
         employeeDao.insertEmployees(employee)
 
         val byName = employeeDao.loadEmployeeByName("Leanne Graham")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application android:name=".NetworkApplication"
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"
@@ -20,7 +21,4 @@
             </intent-filter>
         </activity>
     </application>
-
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '8.13.0' apply false
     id 'com.android.library' version '8.13.0' apply false
@@ -7,11 +6,10 @@ plugins {
     id 'com.google.devtools.ksp' version '1.9.20-1.0.14' apply false
 }
 
-// Define compose_version here so all modules can access it
 ext {
-    compose_version = '1.5.4'
+    compose_version = '1.9.2'
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete layout.buildDirectory.get().asFile
 }


### PR DESCRIPTION
### TL;DR

Updated project configuration for Android SDK 36 compatibility and improved build settings.

### What changed?

- Updated SDK configurations: increased minSdk from 21 to 23 and targetSdk from 35 to 36
- Fixed source set configuration to properly include shared test code in both unit and instrumentation tests
- Updated Compose version from 1.5.4 to 1.9.2
- Moved Android permissions to the proper location in the AndroidManifest.xml
- Replaced TestData dependency with direct object creation in EmployeeDaoTest
- Updated Gradle configuration to use local Java home instead of hardcoded JBR-21
- Added Android test results user preferences configuration
- Modernized the clean task implementation in the root build.gradle

### How to test?

1. Build the project and verify it compiles successfully
2. Run the EmployeeDaoTest to ensure database operations work correctly
3. Verify the app runs on devices with API level 23 and above
4. Check that both unit tests and instrumentation tests can access shared test code

### Why make this change?

These updates improve project compatibility with the latest Android SDK while fixing several configuration issues. The increased minSdk requirement ensures better app performance and security on newer devices. The source set configuration fixes ensure proper test isolation and reuse of shared test code. The manifest restructuring follows best practices for Android permission declarations.